### PR TITLE
Mark error as severity 1 and info as severity 3

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -17,7 +17,9 @@ class JsonRequestFormatter(json_log_formatter.JSONFormatter):
         # Convert the log record to a JSON object.
         # See https://docs.gunicorn.org/en/stable/settings.html#access-log-format
 
-        severity = 0 if record.levelname == "INFO" else 1 if record.levelname == "ERROR" else 2
+        severity = (
+            3 if record.levelname == "INFO" else 1 if record.levelname == "ERROR" else 0
+        )
 
         return dict(
             namespace=settings.NAMESPACE,


### PR DESCRIPTION
### What has changed

The severity levels have been corrected to match berlin: ERROR=1, INFO=3, and 0 only if level unknown.

### How to test

Run the server and confirm requests respond with severity 3 in normal operation.

### Who can review

Phil did the work, Linden can review.