### PR TITLE
Ensure created_at field correctly matches ONS requirements

### DIFF
--- a/category_api/logger.py
+++ b/category_api/logger.py
@@ -62,7 +62,7 @@ def setup_logging():
 
     return structlog.get_logger(
         namespace=settings.NAMESPACE,
-        created_at=datetime.utcnow().isoformat(),
+        created_at=datetime.utcnow().isoformat(timespec="milliseconds") + "Z",
         event="",
         severity=3,  # default
     )

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -21,7 +21,7 @@ class JsonRequestFormatter(json_log_formatter.JSONFormatter):
 
         return dict(
             namespace=settings.NAMESPACE,
-            created_at=datetime.datetime.now().isoformat(),
+            created_at=datetime.datetime.utcnow().isoformat(timespec="milliseconds") + "Z",
             event="making request",
             data={
                 "remote_ip": record.args[0],
@@ -44,7 +44,10 @@ class JsonErrorFormatter(json_log_formatter.JSONFormatter):
             event, extra, record
         )
         payload["namespace"] = settings.NAMESPACE
-        payload["created_at"] = payload["time"]
+        # json_log_formatter sets "time" using datetime.utcnow()
+        # https://github.com/marselester/json-log-formatter/blob/
+        #       bf41c57913a92a9b556d9fc0e3165e97daa38f8e/json_log_formatter/__init__.py#L123)
+        payload["created_at"] = payload["time"].isoformat(timespec="milliseconds") + "Z"
         payload["event"] = record.getMessage()
         payload["level"] = record.levelname
         payload["severity"] = 3 if record.levelname == "INFO" else 1 if record.levelname == "ERROR" else 0


### PR DESCRIPTION
### What has changed?

The format of the logger has been standardized and should now match [the ONS standard](https://github.com/ONSdigital/dp-standards/blob/main/LOGGING_STANDARDS.md).

### How to test?

Run the server - check that requests, regular loglines and any `bonn-py` logs all have the correct format. A successful 200 request for `/categories?query=business` should show all of these.

### Who can review?

Phil did the work. Linden can review.