### PR TITLE
Allow logging to cope with cascading errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=ff /app/build/target/wheels/*cp39*.whl /app
 
 WORKDIR /app
 
-COPY .env /app/
+COPY .env.local /app/
 COPY pyproject.toml /app
 COPY poetry.lock /app
 COPY gunicorn_config.py /app

--- a/tests/unit/gunicorn_test.py
+++ b/tests/unit/gunicorn_test.py
@@ -136,9 +136,9 @@ class TestLogFormatting(unittest.TestCase):
 
             # Error logs 
             self.assertEqual(expected["errors"][0]["message"], formatted_log["errors"][0]["message"])
-            assert "routing.py" in formatted_log["errors"][0]["error"][0]["file"]
-            assert "self.lifespan_context(app) as maybe_state:" in formatted_log["errors"][0]["error"][0]["function"]
-            assert formatted_log["errors"][0]["error"][0]["line"]
+            assert "routing.py" in formatted_log["errors"][0]["stack_trace"][0]["file"]
+            assert "self.lifespan_context(app) as maybe_state:" in formatted_log["errors"][0]["stack_trace"][0]["function"]
+            assert formatted_log["errors"][0]["stack_trace"][0]["line"]
             assert parsable_isoformat(formatted_log["created_at"])
             
 def parsable_isoformat(time):


### PR DESCRIPTION
### What

Improved logs to deal with cascading failure. 

### How to review

Run 

```
make build
make run-container
```

This should cause a cascading failure of stack traces which are now outputted as an array under one log message. 

### Who can review

Not me. 