### PR TITLE
Remove level from logs

### DIFF
--- a/category_api/logger.py
+++ b/category_api/logger.py
@@ -31,6 +31,7 @@ def level_to_severity(level):
 
 def add_severity_level(logger, method_name, event_dict):
     event_dict[0][0]["severity"] = level_to_severity(event_dict[0][0]["level"])
+    del event_dict[0][0]["level"]
     return event_dict
 
 


### PR DESCRIPTION
### What

Remove level from logs as it's not matching the ES log template.

### How to review

Follow setup instructions and run the app - should see that application logs (for example configuration startup) no longer have a 'level' on them. 

### Who can review

Not me. 