### PR TITLE
Fix application logging timestamp

### DIFF
--- a/category_api/logger.py
+++ b/category_api/logger.py
@@ -34,9 +34,11 @@ def add_severity_level(logger, method_name, event_dict):
     del event_dict[0][0]["level"]
     return event_dict
 
+
 def remove_microseconds(logger, method_name, event_dict):
     event_dict[0][0]["created_at"] = event_dict[0][0]["created_at"][:-3] + "Z"
     return event_dict
+
 
 def format_errors(*excs: BaseException, trace=None):
     errors = []
@@ -56,7 +58,9 @@ def format_errors(*excs: BaseException, trace=None):
 def setup_logging():
     shared_processors = []
     processors = shared_processors + [
-        structlog.processors.TimeStamper(fmt="%Y-%m-%dT%H:%M:%S.%f", utc=False, key="created_at"),
+        structlog.processors.TimeStamper(
+            fmt="%Y-%m-%dT%H:%M:%S.%f", utc=False, key="created_at"
+        ),
         structlog.stdlib.add_log_level,
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,

--- a/category_api/logger.py
+++ b/category_api/logger.py
@@ -1,6 +1,5 @@
 import logging
 import logging.config
-from datetime import datetime, timezone
 
 import structlog
 import structlog._log_levels

--- a/category_api/server.py
+++ b/category_api/server.py
@@ -23,12 +23,12 @@ def make_app(controllers, settings, settings_bonn):
     app.controllers = controllers
     app.settings = settings
     app.settings_bonn = settings_bonn
-    
+
     routes_spec = importlib.util.find_spec("category_api.routes")
     routes = importlib.util.module_from_spec(routes_spec)
     routes.app = app
     routes_spec.loader.exec_module(routes)
-    
+
     return app
 
 


### PR DESCRIPTION
### What

Fixed issue with application logs coming out as wrong time (currently does startup time in UTC, rather than log time in local time)

### How to review

Setup steps in readme, run app then hit the query endpoint, e.g.

http://localhost:28800/categories?query=claimant+count

Check the logging `created_at` date and see they are at the right times, ones made by the application (as opposed to gunicorn) are `successfully filtered categories by SNR` or `startup configuration`

### Who can review

Not me. 