### PR TITLE
Add audit ignores

### DIFF
--- a/.audit-ignore
+++ b/.audit-ignore
@@ -1,0 +1,2 @@
+GHSA-48p4-8xcf-vxj5 # Ignored as we do not rely on urllib3 to control the number of redirects for an HTTP request in a Pyodide runtime.
+GHSA-pq67-6m6q-mj2v # botocore users not affected

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ export CATEGORY_API_START_TIME = $(shell date +%s)
 export CATEGORY_API_GIT_COMMIT ?= $(shell git rev-parse HEAD)
 export CATEGORY_API_VERSION ?= $(shell git tag --points-at HEAD | grep ^v | head -n 1)
 
+IGNORED=$(shell awk '{print "--ignore-vuln "$$1}' .audit-ignore)
+
 ifneq (,$(wildcard ./.env))
 	include .env
 	export
@@ -36,7 +38,7 @@ check-files:
 	@if [ ! -f ./${CATEGORY_API_FIFU_FILE} ]; then echo "No fifu file present"; exit 1; fi;
 
 audit: deps ## Audits code for vulnerable dependencies
-	poetry run pip-audit
+	poetry run pip-audit $(IGNORED)
 
 audit-fix: deps ## Audits code for vulnerable dependencies and upgrades
 	poetry run pip-audit --fix


### PR DESCRIPTION
### What

Add audit ignores for urllib3.

I did try and upgrade just for the sake of it but it is incompatible with the elasticsearch client we use, which is locked to v7 until we upgrade to OpenSearch.

### How to review

Check looks ok . 

### Who can review

Not me. 